### PR TITLE
Add hacky checkpoints

### DIFF
--- a/platform.cpp
+++ b/platform.cpp
@@ -136,7 +136,6 @@ namespace Platform {
   static void drawLine(glm::vec3 a, glm::vec3 b) {
     //FIXME!!!
     glBegin(GL_LINES);
-    glColor3f(1.0f, 1.0f, 1.0f);
     glVertex3f(a.x, a.y, a.z);
     glVertex3f(b.x, b.y, b.z);
     glEnd();


### PR DESCRIPTION
To progress towards actual gameplay, this adds very basic checkpoints (hardcoded in main.cpp).
The checkpoints are labelled using text. However, they are only drawn and not actually used yet.
My idea for checkpoints is that they will extend to infinity (so for a closed circuit you'd need at least 3 individual checkpoints). They'll be placed along the raceline and race position can be calculated from the distance to the next checkpoint.

* Text drawing has been turned into a lambda now.
* The need for none-device specific coordinates is more and more apparent too: 800, 480 has been hardcoded again.

---

![obligatory screenshot](http://i.imgur.com/pWEd8vs.png)